### PR TITLE
Added yaml error handling for generate-changelog.sh

### DIFF
--- a/scripts/changelog/generate-changelog.sh
+++ b/scripts/changelog/generate-changelog.sh
@@ -107,21 +107,25 @@ if [ -z "$packages_changed" ]; then
     echo -n ""
 else
     echo "$packages_changed" | while read -r name prev_version curr_version; do
-        prev_version=${prev_version//_/.}
-        curr_version=${curr_version//_/.}
-        IFS='.' read -ra PREV <<< "$prev_version"
-        IFS='.' read -ra CURR <<< "$curr_version"
-        upgraded=false
-        downgraded=false
-        for i in {0..2}; do
-            if [[ ${CURR[i]} -gt ${PREV[i]} ]]; then
-                upgraded=true
-                break
-            elif [[ ${CURR[i]} -lt ${PREV[i]} ]]; then
-                downgraded=true
-                break
-            fi
-        done
+        if [[ $name == *".yaml" ]]; then
+            echo -ne "\n  - ${red}$name cannot be diffed: \n    - Old version: $prev_version \n    - New version: $curr_version${normal}"
+        else
+            prev_version=${prev_version//_/.}
+            curr_version=${curr_version//_/.}
+            IFS='.' read -ra PREV <<< "$prev_version"
+            IFS='.' read -ra CURR <<< "$curr_version"
+            upgraded=false
+            downgraded=false
+            for i in {0..2}; do
+                if [[ ${CURR[i]} -gt ${PREV[i]} ]]; then
+                    upgraded=true
+                    break
+                elif [[ ${CURR[i]} -lt ${PREV[i]} ]]; then
+                    downgraded=true
+                    break
+                fi
+            done
+        fi
         if $upgraded; then
             echo -ne "\n  - ${blue}$name: Upgraded from $prev_version to $curr_version${normal}"
         elif $downgraded; then


### PR DESCRIPTION
### Why
Required to remove the error messages when processing the "Changed packages" function  for packages that are yaml files

### What changed?
- Added a check to see if the package name contains `.yaml`, if it does, print the package name along with the old/new versions and skip the diff of those files

### Screenshots
Error when diffing `.yaml` files:
![image](https://github.com/user-attachments/assets/b6e4d568-3f90-44f2-a228-fe03e0c8f526)

New text displayed instead of errors when diffing `.yaml` files:
![image](https://github.com/user-attachments/assets/733a4fab-7e51-416c-b671-1f961683b2d1)

### Considerations
This could also be achieved by removing the processing of the `.yaml` files all together, but this way there is still some visibility into what is changing