### PR TITLE
Add pointer to digestabot-examples

### DIFF
--- a/digestabot/README.md
+++ b/digestabot/README.md
@@ -1,0 +1,6 @@
+# Digestabot
+
+The [digestabot-examples](https://github.com/chainguard-dev/digestabot-examples)
+repository demonstrates how to use
+[digestabot](https://github.com/chainguard-dev/digestabot) to update images and
+how to extend its functionality for different use cases.


### PR DESCRIPTION
The `digestabot-examples` are in a separate repository but we should aim to try and keep public facing examples centralised.

Hence, putting a link to it here.