### PR TITLE
Add IronPDF .NET Docker POC

### DIFF
--- a/dockerfiles/ironpdf/.dockerignore
+++ b/dockerfiles/ironpdf/.dockerignore
@@ -1,0 +1,7 @@
+**/bin
+**/obj
+out
+.git
+.vscode
+.idea
+*.md

--- a/dockerfiles/ironpdf/.github/workflows/generate-pdf.yml
+++ b/dockerfiles/ironpdf/.github/workflows/generate-pdf.yml
@@ -1,0 +1,55 @@
+name: Generate PDF
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  generate-pdf:
+    name: Build and render PDF
+    runs-on: ubuntu-latest
+    env:
+      IRONPDF_LICENSE_KEY: ${{ secrets.IRONPDF_LICENSE_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Verify license key is set
+        run: |
+          if [[ -z "$IRONPDF_LICENSE_KEY" ]]; then
+            echo "::error::IRONPDF_LICENSE_KEY repo secret is required."
+            echo "Add it under Settings → Secrets and variables → Actions."
+            echo "A 30-day trial key is available at https://ironpdf.com/#trial-license."
+            exit 1
+          fi
+
+      - name: Build image
+        run: make build
+
+      - name: Render PDF
+        run: |
+          mkdir -p out
+          chmod 0777 out
+          docker run --rm \
+            -e IRONPDF_LICENSE_KEY \
+            -v "$PWD/out:/out" \
+            ironpdf-poc:dev
+
+      - name: Validate PDF
+        run: |
+          test -s out/hello.pdf
+          head -c 4 out/hello.pdf | grep -q '%PDF'
+          size=$(wc -c < out/hello.pdf)
+          echo "::notice title=PDF rendered::out/hello.pdf is $size bytes"
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v7
+        with:
+          path: out/hello.pdf
+          archive: false   # download directly as hello.pdf — no zip wrapper
+          retention-days: 30
+          if-no-files-found: error

--- a/dockerfiles/ironpdf/.gitignore
+++ b/dockerfiles/ironpdf/.gitignore
@@ -1,0 +1,9 @@
+out/
+**/bin/
+**/obj/
+.vs/
+.vscode/
+.idea/
+*.user
+docs-internal
+CLAUDE.md

--- a/dockerfiles/ironpdf/Dockerfile
+++ b/dockerfiles/ironpdf/Dockerfile
@@ -1,0 +1,36 @@
+FROM --platform=linux/amd64 cgr.dev/chainguard/dotnet-runtime:latest AS runtime
+FROM --platform=linux/amd64 cgr.dev/chainguard/dotnet-sdk:latest-dev AS build
+USER root
+WORKDIR /src
+
+COPY --from=runtime / /base-chroot
+# Add IronPDF dependencies, approximated from IronPDF's debian dep lists
+RUN apk add --no-cache --no-commit-hooks --no-scripts --root /base-chroot --no-cache \
+      ca-certificates-bundle \
+      libnss libnspr libudev \
+      alsa-lib \
+      libatk-1.0 libatk-bridge-2.0 at-spi2-core \
+      cairo cups-libs dbus libdrm libexpat1 libfontconfig1 mesa-gbm \
+      glib gtk-3 pango \
+      libx11 libxcb libxcomposite libxdamage libxext libxfixes libxkbcommon libxrandr \
+      font-liberation
+
+# Copy in .NET dependencies and then pull them in
+COPY app/IronPdfPoc.csproj ./
+RUN dotnet restore IronPdfPoc.csproj
+
+# Add and compile the application in a new layer
+COPY app/Program.cs ./
+RUN dotnet publish IronPdfPoc.csproj -c Release --no-restore -o /publish
+
+# Build the app into a minimal .NET runtime image with no `apk`
+FROM --platform=linux/amd64 cgr.dev/chainguard/dotnet-runtime:latest
+
+# Copy the chroot with all the dependencies, then copy the app on top of it 
+COPY --from=build /base-chroot /
+
+WORKDIR /app
+COPY --from=build --chown=65532:65532 /publish/ ./
+
+VOLUME ["/out"]
+ENTRYPOINT ["dotnet", "/app/IronPdfPoc.dll"]

--- a/dockerfiles/ironpdf/Makefile
+++ b/dockerfiles/ironpdf/Makefile
@@ -1,0 +1,28 @@
+IMAGE      ?= ironpdf-poc
+TAG        ?= dev
+PLATFORM   ?= linux/amd64
+OUT_DIR    ?= $(CURDIR)/out
+
+.PHONY: help build run smoke clean
+
+help: ## Show this help
+	@awk 'BEGIN { FS = ":.*##" } /^[a-zA-Z_-]+:.*##/ { printf "  %-12s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+build: ## Build the image
+	docker buildx build --platform $(PLATFORM) -t $(IMAGE):$(TAG) --load .
+
+run: ## Run the image and write a PDF to ./out/hello.pdf
+	@mkdir -p $(OUT_DIR)
+	docker run --rm \
+	  -e IRONPDF_LICENSE_KEY \
+	  -v $(OUT_DIR):/out \
+	  $(IMAGE):$(TAG)
+
+smoke: build run ## Build then run, asserting a valid PDF was produced
+	@test -s $(OUT_DIR)/hello.pdf || { echo "FAIL: $(OUT_DIR)/hello.pdf missing or empty"; exit 1; }
+	@head -c 4 $(OUT_DIR)/hello.pdf | grep -q '%PDF' || { echo "FAIL: $(OUT_DIR)/hello.pdf is not a PDF"; exit 1; }
+	@echo "OK: $(OUT_DIR)/hello.pdf is a valid PDF ($$(wc -c < $(OUT_DIR)/hello.pdf) bytes)"
+
+clean: ## Remove built image and rendered PDFs
+	-docker image rm $(IMAGE):$(TAG)
+	rm -rf $(OUT_DIR)

--- a/dockerfiles/ironpdf/README.md
+++ b/dockerfiles/ironpdf/README.md
@@ -1,0 +1,52 @@
+# IronPDF on Chainguard Images
+
+A reference Dockerfile that runs [IronPDF](https://ironpdf.com/get-started/ironpdf-docker/) on Chainguard Images instead of `mcr.microsoft.com/dotnet/*`. The included demo app renders one HTML page to PDF as a smoke test.
+
+## Layout
+
+```text
+.
+├── Dockerfile          # chainguard/dotnet-sdk → chainguard/wolfi-base
+├── Makefile            # `make build`, `make run`, `make smoke`, `make clean`
+├── app/
+│   ├── IronPdfPoc.csproj
+│   └── Program.cs          # Renders one HTML page to /out/hello.pdf
+└── .github/workflows/generate-pdf.yml  # CI: builds the image and uploads hello.pdf as an artefact
+```
+
+## Quick start
+
+You'll need an IronPDF licence key (a 30-day trial is at <https://ironpdf.com/#trial-license>).
+
+```sh
+export IRONPDF_LICENSE_KEY="..."
+make smoke   # build, run, and verify out/hello.pdf is a real PDF
+```
+
+## CI
+
+The `Generate PDF` workflow runs on push, on PR, and on demand (Actions tab → **Run workflow**). It needs an `IRONPDF_LICENSE_KEY` repo secret. Each run uploads the rendered `hello.pdf` to Github artifacts.
+
+## IronPDF Config
+
+IronPDF's standard .NET package is built on a very outdated version of `glibc` and Chromium, which makes it incompatible with Chainguard's base images. To make things happy, we use IronPDF's [`IronPDF.UpdatedChrome.Linux` package](https://ironpdf.com/troubleshooting/ironpdf-native-updated-chrome/) instead, which is built with a more modern version of Chromium. 
+
+The `UpdatedChrome` version has a few constraints, as listed in IronPDF's docs:
+> * SingleProcess is not available.
+> * Windows Server 2012 is not supported.
+> * 32-bit processes are no longer supported.
+
+We also tell IronPDF not to install its own dependencies at runtime (since we pull them in via Chainguard APKs instead), and we disable GPU rendering:
+
+  ```csharp
+  Installation.LinuxAndDockerDependenciesAutoConfig = false;
+  Installation.ChromeGpuMode = ChromeGpuModes.Disabled;
+  ```
+
+## Adapting this to a real app
+
+1. Replace `app/Program.cs` and `app/IronPdfPoc.csproj` with your own project.
+2. Keep the two `Installation.*` lines somewhere on the startup path.
+3. Keep the `IronPdf.UpdatedChrome.Linux` package reference (rather than `IronPdf.Linux`).
+4. Keep the `apk add` list — it is the IronPDF dep set, not anything project-specific.
+5. If you target a different .NET version, swap to the appropriate tag (`9`, `8` etc) and update `<TargetFramework>` accordingly.

--- a/dockerfiles/ironpdf/app/IronPdfPoc.csproj
+++ b/dockerfiles/ironpdf/app/IronPdfPoc.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>IronPdfPoc</AssemblyName>
+    <RootNamespace>IronPdfPoc</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IronPdf.UpdatedChrome.Linux" Version="2026.5.2" />
+  </ItemGroup>
+
+</Project>

--- a/dockerfiles/ironpdf/app/Program.cs
+++ b/dockerfiles/ironpdf/app/Program.cs
@@ -1,0 +1,15 @@
+using IronPdf;
+using IronPdf.Engines.Chrome;
+
+if (Environment.GetEnvironmentVariable("IRONPDF_LICENSE_KEY") is { Length: > 0 } key)
+{
+    License.LicenseKey = key;
+}
+
+Installation.LinuxAndDockerDependenciesAutoConfig = false;
+Installation.ChromeGpuMode = ChromeGpuModes.Disabled;
+
+var output = Environment.GetEnvironmentVariable("OUTPUT_PATH") ?? "/out/hello.pdf";
+var pdf = new ChromePdfRenderer().RenderHtmlAsPdf("<h1>hello from IronPDF on Chainguard</h1>");
+pdf.SaveAs(output);
+Console.WriteLine($"Wrote {output} ({new FileInfo(output).Length} bytes)");


### PR DESCRIPTION
We have a customer who uses IronPDF on Docker, and is struggling to run it on Chainguard. This PR adds a POC for running IronPDF on top of our dotnet images.

I've added the POC folder wholesale, since it'll be handy (for the client) to have the scaffolding around the Dockerfile for them to inspect; in future, we can probably dispose of the GHA and READMEs and just keep the IronPDF Dockerfile.