### PR TITLE
Add Terraform modules for Artifactory libraries setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,36 @@
 fips/java/target/
+
+# Terraform
+**/*.tfvars
+**/*.tfvars.json
+!**/*.example.tfvars
+!**/*.example.tfvars.json
+**/.terraform/
+**/.terraform.lock.hcl
+**/terraform.tfstate
+**/terraform.tfstate.*
+**/*.tfplan
+**/*.tfplan.*
+**/crash.log
+**/crash.*.log
+**/.terraformrc
+**/terraform.rc
+**/override.tf
+**/override.tf.json
+**/*_override.tf
+**/*_override.tf.json
+
+# Credentials / secrets
+**/.npmrc
+**/.pypirc
+**/.netrc
+**/.env
+**/.env.*
+!**/.env.example
+**/credentials
+**/credentials.json
+**/*.pem
+**/*.key
+
+# Node
+**/node_modules/

--- a/terraform-modules/README.md
+++ b/terraform-modules/README.md
@@ -1,0 +1,8 @@
+# Terraform Modules
+
+Terraform modules that configure artifact managers and other systems to work
+with Chainguard in supported configurations.
+
+> [!WARNING]
+> These modules are provided as examples only, without any guarantees of
+> maintenance or ongoing support.

--- a/terraform-modules/artifactory-java-fallback/README.md
+++ b/terraform-modules/artifactory-java-fallback/README.md
@@ -1,0 +1,103 @@
+# Chainguard Libraries for Java — Artifactory
+
+Provisions an Artifactory virtual Maven repository backed by the Chainguard
+remediated index, the Chainguard standard index, and public Maven Central as
+fallback (in that order), following the JFrog Artifactory setup recommended in
+the
+[Chainguard Libraries for Java global configuration docs](https://edu.chainguard.dev/chainguard/libraries/java/global-configuration/#jfrog-artifactory).
+
+## Architecture
+
+```mermaid
+flowchart LR
+    dev[maven / gradle] --> virtual
+    subgraph artifactory["Artifactory"]
+        subgraph virtual["java-all (virtual)"]
+            direction TB
+            rem["java-chainguard-remediated"] -. fallback .-> cg["java-chainguard"]
+            cg -. fallback .-> pub["java-public"]
+        end
+    end
+    subgraph chainguard["libraries.cgr.dev"]
+        cgrem["/java-remediated"]
+        cgstd["/java"]
+    end
+    rem --> cgrem
+    cg --> cgstd
+    pub --> central["repo1.maven.org/maven2/"]
+```
+
+## Usage
+
+1. Generate a Chainguard pull token (replace `<org>` with your organization):
+
+   ```sh
+   eval $(chainctl auth pull-token --output env --repository=java --parent=<org>)
+   ```
+
+   This exports `CHAINGUARD_JAVA_IDENTITY_ID` and `CHAINGUARD_JAVA_TOKEN`.
+
+2. Point the Artifactory provider at your instance:
+
+   ```sh
+   export JFROG_URL=https://example.jfrog.io
+   export JFROG_ACCESS_TOKEN=<artifactory-admin-token>
+   ```
+
+   Generate an admin token in the JFrog UI under Administration → User
+   Management → Access Tokens → Generate Admin Token
+   ([JFrog docs](https://docs.jfrog.com/administration/docs/access-tokens)).
+
+3. Write `terraform.tfvars`:
+
+   ```sh
+   cat > terraform.tfvars <<EOF
+   name                = "your-name"
+   chainguard_username = "${CHAINGUARD_JAVA_IDENTITY_ID}"
+   chainguard_password = "${CHAINGUARD_JAVA_TOKEN}"
+   EOF
+   ```
+
+4. `terraform init && terraform apply`.
+
+Point Maven/Gradle at `https://<artifactory-host>/artifactory/your-name-java-all/`.
+
+## Example
+
+### curl
+
+Smoke-test the virtual (substitute your Artifactory user and access token):
+
+```sh
+curl -u "$JFROG_USER:$JFROG_ACCESS_TOKEN" -LO "$JFROG_URL/artifactory/your-name-java-all/com/google/guava/guava/33.4.0-jre/guava-33.4.0-jre.jar"
+```
+
+### Maven
+
+Add to `~/.m2/settings.xml`:
+
+```xml
+<servers><server><id>cgr</id><username>YOUR_JFROG_USER</username><password>YOUR_JFROG_ACCESS_TOKEN</password></server></servers>
+<mirrors><mirror><id>cgr</id><mirrorOf>*</mirrorOf><url>https://<artifactory-host>/artifactory/your-name-java-all/</url></mirror></mirrors>
+```
+
+```sh
+mvn dependency:get -Dartifact=com.google.guava:guava:33.4.0-jre
+```
+
+### Gradle
+
+In `build.gradle.kts`:
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://<artifactory-host>/artifactory/your-name-java-all/")
+        credentials { username = System.getenv("JFROG_USER"); password = System.getenv("JFROG_ACCESS_TOKEN") }
+    }
+}
+```
+
+```sh
+./gradlew dependencies --configuration runtimeClasspath
+```

--- a/terraform-modules/artifactory-java-fallback/main.tf
+++ b/terraform-modules/artifactory-java-fallback/main.tf
@@ -1,0 +1,57 @@
+locals {
+  remediated_key = "${var.name}-java-chainguard-remediated"
+  chainguard_key = "${var.name}-java-chainguard"
+  public_key     = "${var.name}-java-public"
+  virtual_key    = "${var.name}-java-all"
+
+  remediated_url = "${var.chainguard_libraries_url}/${var.remediated_index_path}/"
+  chainguard_url = "${var.chainguard_libraries_url}/${var.chainguard_index_path}/"
+}
+
+# Remote: Chainguard remediated Java index (highest priority).
+resource "artifactory_remote_maven_repository" "remediated" {
+  key                          = local.remediated_key
+  url                          = local.remediated_url
+  username                     = var.chainguard_username
+  password                     = var.chainguard_password
+  description                  = "${var.description} - remediated index"
+  block_mismatching_mime_types = false
+  # Per Chainguard docs: Maven snapshot handling must be off for the
+  # Chainguard remote so Artifactory does not attempt snapshot resolution.
+  handle_snapshots = false
+  project_key      = var.project_key != "" ? var.project_key : null
+}
+
+# Remote: Chainguard standard Java index.
+resource "artifactory_remote_maven_repository" "chainguard" {
+  key                          = local.chainguard_key
+  url                          = local.chainguard_url
+  username                     = var.chainguard_username
+  password                     = var.chainguard_password
+  description                  = "${var.description} - standard index"
+  block_mismatching_mime_types = false
+  handle_snapshots             = false
+  project_key                  = var.project_key != "" ? var.project_key : null
+}
+
+# Remote: Upstream Maven Central (fallback for artifacts not in Chainguard).
+resource "artifactory_remote_maven_repository" "public" {
+  key              = local.public_key
+  url              = var.maven_central_url
+  description      = "Maven Central fallback"
+  handle_snapshots = false
+  project_key      = var.project_key != "" ? var.project_key : null
+}
+
+# Virtual: aggregates the three remotes with the requested fallback order.
+resource "artifactory_virtual_maven_repository" "all" {
+  key         = local.virtual_key
+  description = "${var.description} - virtual aggregator"
+  repositories = [
+    artifactory_remote_maven_repository.remediated.key,
+    artifactory_remote_maven_repository.chainguard.key,
+    artifactory_remote_maven_repository.public.key,
+  ]
+  default_deployment_repo = var.default_deployment_repo != "" ? var.default_deployment_repo : null
+  project_key             = var.project_key != "" ? var.project_key : null
+}

--- a/terraform-modules/artifactory-java-fallback/outputs.tf
+++ b/terraform-modules/artifactory-java-fallback/outputs.tf
@@ -1,0 +1,19 @@
+output "remediated_repository_key" {
+  description = "Key of the Chainguard remediated remote repository."
+  value       = artifactory_remote_maven_repository.remediated.key
+}
+
+output "chainguard_repository_key" {
+  description = "Key of the Chainguard standard remote repository."
+  value       = artifactory_remote_maven_repository.chainguard.key
+}
+
+output "public_repository_key" {
+  description = "Key of the upstream Maven Central remote repository."
+  value       = artifactory_remote_maven_repository.public.key
+}
+
+output "virtual_repository_key" {
+  description = "Key of the virtual repository aggregating remediated, chainguard, and public in that order."
+  value       = artifactory_virtual_maven_repository.all.key
+}

--- a/terraform-modules/artifactory-java-fallback/variables.tf
+++ b/terraform-modules/artifactory-java-fallback/variables.tf
@@ -1,0 +1,68 @@
+variable "name" {
+  description = "Prefix used for the three remote repositories and the virtual repository. The module appends a `-java-` infix to disambiguate Java repos from other ecosystems. For example, name = \"corp\" yields corp-java-chainguard-remediated, corp-java-chainguard, corp-java-public, and corp-java-all."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.name))
+    error_message = "name must be lowercase alphanumeric with optional hyphens, and must start with a letter or digit."
+  }
+}
+
+variable "chainguard_libraries_url" {
+  description = "Base URL of the Chainguard Libraries service (no trailing slash)."
+  type        = string
+  default     = "https://libraries.cgr.dev"
+
+  validation {
+    condition     = can(regex("^https?://[^/]+$", var.chainguard_libraries_url))
+    error_message = "chainguard_libraries_url must be a scheme + host with no path or trailing slash, e.g. https://libraries.cgr.dev."
+  }
+}
+
+variable "remediated_index_path" {
+  description = "Path segment for the Chainguard remediated Java index, appended to chainguard_libraries_url."
+  type        = string
+  default     = "java-remediated"
+}
+
+variable "chainguard_index_path" {
+  description = "Path segment for the Chainguard standard Java index, appended to chainguard_libraries_url."
+  type        = string
+  default     = "java"
+}
+
+variable "maven_central_url" {
+  description = "URL of the upstream Maven Central repository used as fallback."
+  type        = string
+  default     = "https://repo1.maven.org/maven2/"
+}
+
+variable "chainguard_username" {
+  description = "Username (identity ID) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "chainguard_password" {
+  description = "Password (token) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "description" {
+  description = "Optional description applied to the created repositories."
+  type        = string
+  default     = "Chainguard Libraries for Java"
+}
+
+variable "project_key" {
+  description = "Optional Artifactory project key to assign the repositories to."
+  type        = string
+  default     = ""
+}
+
+variable "default_deployment_repo" {
+  description = "Optional key of a local repository to use as the default deployment target on the virtual repository. Leave empty to disable deployments through the virtual."
+  type        = string
+  default     = ""
+}

--- a/terraform-modules/artifactory-java-fallback/versions.tf
+++ b/terraform-modules/artifactory-java-fallback/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    artifactory = {
+      source  = "jfrog/artifactory"
+      version = ">= 12.0.0"
+    }
+  }
+}

--- a/terraform-modules/artifactory-javascript-fallback/README.md
+++ b/terraform-modules/artifactory-javascript-fallback/README.md
@@ -1,13 +1,14 @@
 # Chainguard Libraries for JavaScript with public npm fallback — Artifactory
 
 > [!WARNING]
-> Prefer the [`javascript`](../javascript/) module over this one. The
-> Chainguard Repository for JavaScript has built-in upstream fallback that
-> enforces malware scanning and a publish cooldown on newly-released packages;
-> the `javascript` module points Artifactory at that endpoint and lets
-> Chainguard handle the fallback. This module instead has Artifactory itself
-> fall back to public npm, which bypasses those protections. Use it only when
-> Chainguard's upstream fallback is disabled by policy.
+> Prefer the [`artifactory-javascript`](../artifactory-javascript/) module
+> over this one. The Chainguard Repository for JavaScript has built-in
+> upstream fallback that enforces malware scanning and a publish cooldown on
+> newly-released packages; the `artifactory-javascript` module points
+> Artifactory at that endpoint and lets Chainguard handle the fallback. This
+> module instead has Artifactory itself fall back to public npm, which
+> bypasses those protections. Use it only when Chainguard's upstream fallback
+> is disabled by policy.
 
 Provisions an Artifactory virtual npm repository backed by a Chainguard remote
 and a public npm remote (in that order), following the JFrog Artifactory setup

--- a/terraform-modules/artifactory-javascript-fallback/README.md
+++ b/terraform-modules/artifactory-javascript-fallback/README.md
@@ -1,0 +1,108 @@
+# Chainguard Libraries for JavaScript with public npm fallback — Artifactory
+
+> [!WARNING]
+> Prefer the [`javascript`](../javascript/) module over this one. The
+> Chainguard Repository for JavaScript has built-in upstream fallback that
+> enforces malware scanning and a publish cooldown on newly-released packages;
+> the `javascript` module points Artifactory at that endpoint and lets
+> Chainguard handle the fallback. This module instead has Artifactory itself
+> fall back to public npm, which bypasses those protections. Use it only when
+> Chainguard's upstream fallback is disabled by policy.
+
+Provisions an Artifactory virtual npm repository backed by a Chainguard remote
+and a public npm remote (in that order), following the JFrog Artifactory setup
+recommended in the
+[Chainguard Libraries for JavaScript global configuration docs](https://edu.chainguard.dev/chainguard/libraries/javascript/global-configuration/#jfrog-artifactory),
+extended with a public npm fallback.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    dev[npm / pnpm / yarn] --> virtual
+    subgraph artifactory["Artifactory"]
+        subgraph virtual["js-all (virtual)"]
+            direction TB
+            cg["js-chainguard"] -. fallback .-> pub["js-public"]
+        end
+    end
+    subgraph chainguard["libraries.cgr.dev"]
+        cgrdev["/javascript"]
+    end
+    cg --> cgrdev
+    pub --> npmjs["registry.npmjs.org"]
+```
+
+## Usage
+
+1. Generate a Chainguard pull token (replace `<org>` with your organization):
+
+   ```sh
+   eval $(chainctl auth pull-token --output env --repository=javascript --parent=<org>)
+   ```
+
+   This exports `CHAINGUARD_JAVASCRIPT_IDENTITY_ID` and `CHAINGUARD_JAVASCRIPT_TOKEN`.
+
+2. Point the Artifactory provider at your instance:
+
+   ```sh
+   export JFROG_URL=https://example.jfrog.io
+   export JFROG_ACCESS_TOKEN=<artifactory-admin-token>
+   ```
+
+   Generate an admin token in the JFrog UI under Administration → User
+   Management → Access Tokens → Generate Admin Token
+   ([JFrog docs](https://docs.jfrog.com/administration/docs/access-tokens)).
+
+3. Write `terraform.tfvars`:
+
+   ```sh
+   cat > terraform.tfvars <<EOF
+   name                = "your-name"
+   chainguard_username = "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}"
+   chainguard_password = "${CHAINGUARD_JAVASCRIPT_TOKEN}"
+   EOF
+   ```
+
+4. `terraform init && terraform apply`.
+
+Point your package manager at `https://<artifactory-host>/artifactory/api/npm/your-name-js-all/`.
+
+## Example
+
+### curl
+
+Smoke-test the virtual:
+
+```sh
+curl -u "$JFROG_USER:$JFROG_ACCESS_TOKEN" -L "$JFROG_URL/artifactory/api/npm/your-name-js-all/lodash" | head -5
+```
+
+### npm
+
+```sh
+npm config set registry "https://<artifactory-host>/artifactory/api/npm/your-name-js-all/" && npm config set "//<artifactory-host>/artifactory/api/npm/your-name-js-all/:_authToken" "$JFROG_ACCESS_TOKEN"
+npm install lodash
+```
+
+### pnpm
+
+```sh
+pnpm config set registry "https://<artifactory-host>/artifactory/api/npm/your-name-js-all/" && pnpm config set "//<artifactory-host>/artifactory/api/npm/your-name-js-all/:_authToken" "$JFROG_ACCESS_TOKEN"
+pnpm add lodash
+```
+
+### Yarn Berry (v2+)
+
+In `.yarnrc.yml`:
+
+```yaml
+npmRegistryServer: "https://<artifactory-host>/artifactory/api/npm/your-name-js-all/"
+npmRegistries:
+  "//<artifactory-host>/artifactory/api/npm/your-name-js-all":
+    npmAuthToken: "${JFROG_ACCESS_TOKEN}"
+```
+
+```sh
+yarn add lodash
+```

--- a/terraform-modules/artifactory-javascript-fallback/main.tf
+++ b/terraform-modules/artifactory-javascript-fallback/main.tf
@@ -1,0 +1,45 @@
+locals {
+  chainguard_key = "${var.name}-js-chainguard"
+  public_key     = "${var.name}-js-public"
+  virtual_key    = "${var.name}-js-all"
+
+  chainguard_url = "${var.chainguard_libraries_url}/${var.chainguard_index_path}/"
+}
+
+# Remote: Chainguard npm index (highest priority).
+resource "artifactory_remote_npm_repository" "chainguard" {
+  key         = local.chainguard_key
+  url         = local.chainguard_url
+  username    = var.chainguard_username
+  password    = var.chainguard_password
+  description = "${var.description} - Chainguard index"
+  # Chainguard's npm index 302s to Cloudflare R2 pre-signed URLs. Default URL
+  # normalization re-encodes the redirect target and breaks the AWS signature,
+  # producing 404s on tarball downloads.
+  disable_url_normalization = true
+  # Per Chainguard docs: the upstream rejects HEAD requests against tarball
+  # paths; without this, Artifactory's pre-flight HEAD fails and the GET is
+  # never attempted, so tarball fetches return 404.
+  bypass_head_requests = true
+  project_key          = var.project_key != "" ? var.project_key : null
+}
+
+# Remote: Upstream public npm registry (fallback for packages not in Chainguard).
+resource "artifactory_remote_npm_repository" "public" {
+  key         = local.public_key
+  url         = var.npm_registry_url
+  description = "Public npm registry fallback"
+  project_key = var.project_key != "" ? var.project_key : null
+}
+
+# Virtual: aggregates the two remotes with Chainguard first, public npm fallback.
+resource "artifactory_virtual_npm_repository" "all" {
+  key         = local.virtual_key
+  description = "${var.description} - virtual aggregator"
+  repositories = [
+    artifactory_remote_npm_repository.chainguard.key,
+    artifactory_remote_npm_repository.public.key,
+  ]
+  default_deployment_repo = var.default_deployment_repo != "" ? var.default_deployment_repo : null
+  project_key             = var.project_key != "" ? var.project_key : null
+}

--- a/terraform-modules/artifactory-javascript-fallback/outputs.tf
+++ b/terraform-modules/artifactory-javascript-fallback/outputs.tf
@@ -1,0 +1,14 @@
+output "chainguard_repository_key" {
+  description = "Key of the Chainguard npm remote repository."
+  value       = artifactory_remote_npm_repository.chainguard.key
+}
+
+output "public_repository_key" {
+  description = "Key of the upstream public npm remote repository."
+  value       = artifactory_remote_npm_repository.public.key
+}
+
+output "virtual_repository_key" {
+  description = "Key of the virtual repository aggregating chainguard and public in that order."
+  value       = artifactory_virtual_npm_repository.all.key
+}

--- a/terraform-modules/artifactory-javascript-fallback/variables.tf
+++ b/terraform-modules/artifactory-javascript-fallback/variables.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  description = "Prefix used for the two remote repositories and the virtual repository. The module appends a `-js-` infix to disambiguate JavaScript repos from other ecosystems. For example, name = \"corp\" yields corp-js-chainguard, corp-js-public, and corp-js-all."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.name))
+    error_message = "name must be lowercase alphanumeric with optional hyphens, and must start with a letter or digit."
+  }
+}
+
+variable "chainguard_libraries_url" {
+  description = "Base URL of the Chainguard Libraries service (no trailing slash)."
+  type        = string
+  default     = "https://libraries.cgr.dev"
+
+  validation {
+    condition     = can(regex("^https?://[^/]+$", var.chainguard_libraries_url))
+    error_message = "chainguard_libraries_url must be a scheme + host with no path or trailing slash, e.g. https://libraries.cgr.dev."
+  }
+}
+
+variable "chainguard_index_path" {
+  description = "Path segment for the Chainguard JavaScript index, appended to chainguard_libraries_url."
+  type        = string
+  default     = "javascript"
+}
+
+variable "npm_registry_url" {
+  description = "URL of the upstream npm registry used as fallback."
+  type        = string
+  default     = "https://registry.npmjs.org"
+}
+
+variable "chainguard_username" {
+  description = "Username (identity ID) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "chainguard_password" {
+  description = "Password (token) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "description" {
+  description = "Optional description applied to the created repositories."
+  type        = string
+  default     = "Chainguard Libraries for JavaScript"
+}
+
+variable "project_key" {
+  description = "Optional Artifactory project key to assign the repositories to."
+  type        = string
+  default     = ""
+}
+
+variable "default_deployment_repo" {
+  description = "Optional key of a local repository to use as the default deployment target on the virtual repository. Leave empty to disable deployments through the virtual."
+  type        = string
+  default     = ""
+}

--- a/terraform-modules/artifactory-javascript-fallback/versions.tf
+++ b/terraform-modules/artifactory-javascript-fallback/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    artifactory = {
+      source  = "jfrog/artifactory"
+      version = ">= 12.0.0"
+    }
+  }
+}

--- a/terraform-modules/artifactory-javascript/README.md
+++ b/terraform-modules/artifactory-javascript/README.md
@@ -1,0 +1,96 @@
+# Chainguard Libraries for JavaScript — Artifactory (single remote)
+
+Provisions a single Artifactory npm remote repository pointed at the
+Chainguard JavaScript index (or any upstream npm registry you specify),
+following the JFrog Artifactory setup recommended in the
+[Chainguard Libraries for JavaScript global configuration docs](https://edu.chainguard.dev/chainguard/libraries/javascript/global-configuration/#jfrog-artifactory).
+This is the recommended setup when you rely on Chainguard's own upstream
+fallback rather than fronting Chainguard with a virtual repo.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    dev[npm / pnpm / yarn] --> remote
+    subgraph artifactory["Artifactory"]
+        remote["js-public (remote)"]
+    end
+    subgraph chainguard["libraries.cgr.dev"]
+        cgrdev["/javascript"]
+    end
+    remote --> cgrdev
+```
+
+## Usage
+
+1. Generate a Chainguard pull token (replace `<org>` with your organization):
+
+   ```sh
+   eval $(chainctl auth pull-token --output env --repository=javascript --parent=<org>)
+   ```
+
+   This exports `CHAINGUARD_JAVASCRIPT_IDENTITY_ID` and `CHAINGUARD_JAVASCRIPT_TOKEN`.
+
+2. Point the Artifactory provider at your instance:
+
+   ```sh
+   export JFROG_URL=https://example.jfrog.io
+   export JFROG_ACCESS_TOKEN=<artifactory-admin-token>
+   ```
+
+   Generate an admin token in the JFrog UI under Administration → User
+   Management → Access Tokens → Generate Admin Token
+   ([JFrog docs](https://docs.jfrog.com/administration/docs/access-tokens)).
+
+3. Write `terraform.tfvars`:
+
+   ```sh
+   cat > terraform.tfvars <<EOF
+   name     = "your-name"
+   username = "${CHAINGUARD_JAVASCRIPT_IDENTITY_ID}"
+   password = "${CHAINGUARD_JAVASCRIPT_TOKEN}"
+   EOF
+   ```
+
+4. `terraform init && terraform apply`.
+
+Point your package manager at `https://<artifactory-host>/artifactory/api/npm/your-name-js-public/`.
+
+## Example
+
+### curl
+
+Smoke-test the remote:
+
+```sh
+curl -u "$JFROG_USER:$JFROG_ACCESS_TOKEN" -L "$JFROG_URL/artifactory/api/npm/your-name-js-public/lodash" | head -5
+```
+
+### npm
+
+```sh
+npm config set registry "https://<artifactory-host>/artifactory/api/npm/your-name-js-public/" && npm config set "//<artifactory-host>/artifactory/api/npm/your-name-js-public/:_authToken" "$JFROG_ACCESS_TOKEN"
+npm install lodash
+```
+
+### pnpm
+
+```sh
+pnpm config set registry "https://<artifactory-host>/artifactory/api/npm/your-name-js-public/" && pnpm config set "//<artifactory-host>/artifactory/api/npm/your-name-js-public/:_authToken" "$JFROG_ACCESS_TOKEN"
+pnpm add lodash
+```
+
+### Yarn Berry (v2+)
+
+In `.yarnrc.yml`:
+
+```yaml
+npmRegistryServer: "https://<artifactory-host>/artifactory/api/npm/your-name-js-public/"
+npmRegistries:
+  "//<artifactory-host>/artifactory/api/npm/your-name-js-public":
+    npmAuthToken: "${JFROG_ACCESS_TOKEN}"
+```
+
+```sh
+yarn add lodash
+```

--- a/terraform-modules/artifactory-javascript/main.tf
+++ b/terraform-modules/artifactory-javascript/main.tf
@@ -1,0 +1,21 @@
+locals {
+  public_key = "${var.name}-js-public"
+}
+
+# Remote: npm registry proxy (defaults to upstream npm; can point at Chainguard).
+resource "artifactory_remote_npm_repository" "public" {
+  key         = local.public_key
+  url         = var.npm_registry_url
+  description = var.description
+  username    = var.username != "" ? var.username : null
+  password    = var.password != "" ? var.password : null
+  # Chainguard's npm index 302s to Cloudflare R2 pre-signed URLs. Default URL
+  # normalization re-encodes the redirect target and breaks the AWS signature,
+  # producing 404s on tarball downloads.
+  disable_url_normalization = true
+  # The upstream rejects HEAD requests against tarball paths; without this,
+  # Artifactory's pre-flight HEAD fails and the GET is never attempted, so
+  # tarball fetches return 404.
+  bypass_head_requests = true
+  project_key          = var.project_key != "" ? var.project_key : null
+}

--- a/terraform-modules/artifactory-javascript/outputs.tf
+++ b/terraform-modules/artifactory-javascript/outputs.tf
@@ -1,0 +1,4 @@
+output "public_repository_key" {
+  description = "Key of the upstream npm remote repository."
+  value       = artifactory_remote_npm_repository.public.key
+}

--- a/terraform-modules/artifactory-javascript/variables.tf
+++ b/terraform-modules/artifactory-javascript/variables.tf
@@ -1,0 +1,41 @@
+variable "name" {
+  description = "Prefix used for the remote repository. The module appends a `-js-` infix to disambiguate JavaScript repos from other ecosystems. For example, name = \"corp\" yields corp-js-public."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.name))
+    error_message = "name must be lowercase alphanumeric with optional hyphens, and must start with a letter or digit."
+  }
+}
+
+variable "npm_registry_url" {
+  description = "URL of the upstream npm registry to proxy. Defaults to the Chainguard JavaScript index."
+  type        = string
+  default     = "https://libraries.cgr.dev/javascript/"
+}
+
+variable "username" {
+  description = "Username for authenticating to the upstream registry (the Chainguard identity ID for the default upstream). Leave empty for unauthenticated upstreams."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "password" {
+  description = "Optional password/token for authenticating to the upstream registry."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "description" {
+  description = "Optional description applied to the created repository."
+  type        = string
+  default     = "Upstream npm registry proxy"
+}
+
+variable "project_key" {
+  description = "Optional Artifactory project key to assign the repository to."
+  type        = string
+  default     = ""
+}

--- a/terraform-modules/artifactory-javascript/versions.tf
+++ b/terraform-modules/artifactory-javascript/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    artifactory = {
+      source  = "jfrog/artifactory"
+      version = ">= 12.0.0"
+    }
+  }
+}

--- a/terraform-modules/artifactory-python-fallback/README.md
+++ b/terraform-modules/artifactory-python-fallback/README.md
@@ -1,0 +1,92 @@
+# Chainguard Libraries for Python — Artifactory
+
+Provisions an Artifactory virtual PyPI repository backed by the Chainguard
+remediated index, the Chainguard standard index, and public PyPI as fallback
+(in that order), following the JFrog Artifactory setup recommended in the
+[Chainguard Libraries for Python management docs](https://edu.chainguard.dev/chainguard/libraries/python/management/#jfrog-artifactory).
+
+## Architecture
+
+```mermaid
+flowchart LR
+    dev[pip / uv / poetry] --> virtual
+    subgraph artifactory["Artifactory"]
+        subgraph virtual["py-all (virtual)"]
+            direction TB
+            rem["py-chainguard-remediated"] -. fallback .-> cg["py-chainguard"]
+            cg -. fallback .-> pub["py-public"]
+        end
+    end
+    subgraph chainguard["libraries.cgr.dev"]
+        cgrem["/python-remediated"]
+        cgstd["/python"]
+    end
+    rem --> cgrem
+    cg --> cgstd
+    pub --> pypi["files.pythonhosted.org"]
+```
+
+## Usage
+
+1. Generate a Chainguard pull token (replace `<org>` with your organization):
+
+   ```sh
+   eval $(chainctl auth pull-token --output env --repository=python --parent=<org>)
+   ```
+
+   This exports `CHAINGUARD_PYTHON_IDENTITY_ID` and `CHAINGUARD_PYTHON_TOKEN`.
+
+2. Point the Artifactory provider at your instance:
+
+   ```sh
+   export JFROG_URL=https://example.jfrog.io
+   export JFROG_ACCESS_TOKEN=<artifactory-admin-token>
+   ```
+
+   Generate an admin token in the JFrog UI under Administration → User
+   Management → Access Tokens → Generate Admin Token
+   ([JFrog docs](https://docs.jfrog.com/administration/docs/access-tokens)).
+
+3. Write `terraform.tfvars`:
+
+   ```sh
+   cat > terraform.tfvars <<EOF
+   name                = "your-name"
+   chainguard_username = "${CHAINGUARD_PYTHON_IDENTITY_ID}"
+   chainguard_password = "${CHAINGUARD_PYTHON_TOKEN}"
+   EOF
+   ```
+
+4. `terraform init && terraform apply`.
+
+Point pip at `https://<artifactory-host>/artifactory/api/pypi/your-name-py-all/simple/`.
+
+## Example
+
+### curl
+
+Smoke-test the virtual:
+
+```sh
+curl -u "$JFROG_USER:$JFROG_ACCESS_TOKEN" -L "$JFROG_URL/artifactory/api/pypi/your-name-py-all/simple/requests/" | head -5
+```
+
+### pip
+
+```sh
+pip install --index-url "https://$JFROG_USER:$JFROG_ACCESS_TOKEN@<artifactory-host>/artifactory/api/pypi/your-name-py-all/simple/" requests
+```
+
+### uv
+
+```sh
+uv pip install --index-url "https://$JFROG_USER:$JFROG_ACCESS_TOKEN@<artifactory-host>/artifactory/api/pypi/your-name-py-all/simple/" requests
+```
+
+### Poetry
+
+```sh
+poetry source add cgr "https://<artifactory-host>/artifactory/api/pypi/your-name-py-all/simple/"
+poetry config http-basic.cgr "$JFROG_USER" "$JFROG_ACCESS_TOKEN"
+poetry add requests
+```

--- a/terraform-modules/artifactory-python-fallback/main.tf
+++ b/terraform-modules/artifactory-python-fallback/main.tf
@@ -1,0 +1,61 @@
+locals {
+  remediated_key = "${var.name}-py-chainguard-remediated"
+  chainguard_key = "${var.name}-py-chainguard"
+  public_key     = "${var.name}-py-public"
+  virtual_key    = "${var.name}-py-all"
+
+  remediated_url = "${var.chainguard_libraries_url}/${var.remediated_index_path}/"
+  chainguard_url = "${var.chainguard_libraries_url}/${var.chainguard_index_path}/"
+}
+
+# Remote: Chainguard remediated Python index (highest priority).
+resource "artifactory_remote_pypi_repository" "remediated" {
+  key                          = local.remediated_key
+  url                          = local.remediated_url
+  username                     = var.chainguard_username
+  password                     = var.chainguard_password
+  description                  = "${var.description} - remediated index"
+  pypi_registry_url            = local.remediated_url
+  block_mismatching_mime_types = false
+  # Required: wheels are served via a 302 redirect to a Cloudflare R2 pre-signed
+  # URL; default URL normalization re-encodes the redirect target and breaks
+  # the AWS signature, causing 404s on wheel downloads.
+  disable_url_normalization = true
+  project_key               = var.project_key != "" ? var.project_key : null
+}
+
+# Remote: Chainguard standard Python index.
+resource "artifactory_remote_pypi_repository" "chainguard" {
+  key                          = local.chainguard_key
+  url                          = local.chainguard_url
+  username                     = var.chainguard_username
+  password                     = var.chainguard_password
+  description                  = "${var.description} - standard index"
+  pypi_registry_url            = local.chainguard_url
+  block_mismatching_mime_types = false
+  # See note on remediated remote: required for R2 pre-signed URL redirects.
+  disable_url_normalization = true
+  project_key               = var.project_key != "" ? var.project_key : null
+}
+
+# Remote: Upstream public PyPI (fallback for packages not in Chainguard).
+resource "artifactory_remote_pypi_repository" "public" {
+  key               = local.public_key
+  url               = "https://files.pythonhosted.org/"
+  description       = "Public PyPI fallback"
+  pypi_registry_url = "https://pypi.org"
+  project_key       = var.project_key != "" ? var.project_key : null
+}
+
+# Virtual: aggregates the three remotes with the requested fallback order.
+resource "artifactory_virtual_pypi_repository" "all" {
+  key         = local.virtual_key
+  description = "${var.description} - virtual aggregator"
+  repositories = [
+    artifactory_remote_pypi_repository.remediated.key,
+    artifactory_remote_pypi_repository.chainguard.key,
+    artifactory_remote_pypi_repository.public.key,
+  ]
+  default_deployment_repo = var.default_deployment_repo != "" ? var.default_deployment_repo : null
+  project_key             = var.project_key != "" ? var.project_key : null
+}

--- a/terraform-modules/artifactory-python-fallback/outputs.tf
+++ b/terraform-modules/artifactory-python-fallback/outputs.tf
@@ -1,0 +1,19 @@
+output "remediated_repository_key" {
+  description = "Key of the Chainguard remediated remote repository."
+  value       = artifactory_remote_pypi_repository.remediated.key
+}
+
+output "chainguard_repository_key" {
+  description = "Key of the Chainguard standard remote repository."
+  value       = artifactory_remote_pypi_repository.chainguard.key
+}
+
+output "public_repository_key" {
+  description = "Key of the upstream PyPI remote repository."
+  value       = artifactory_remote_pypi_repository.public.key
+}
+
+output "virtual_repository_key" {
+  description = "Key of the virtual repository aggregating remediated, chainguard, and public in that order."
+  value       = artifactory_virtual_pypi_repository.all.key
+}

--- a/terraform-modules/artifactory-python-fallback/variables.tf
+++ b/terraform-modules/artifactory-python-fallback/variables.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  description = "Prefix used for the three remote repositories and the virtual repository. The module appends a `-py-` infix to disambiguate Python repos from other ecosystems. For example, name = \"corp\" yields corp-py-chainguard-remediated, corp-py-chainguard, corp-py-public, and corp-py-all."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.name))
+    error_message = "name must be lowercase alphanumeric with optional hyphens, and must start with a letter or digit."
+  }
+}
+
+variable "chainguard_libraries_url" {
+  description = "Base URL of the Chainguard Libraries service (no trailing slash)."
+  type        = string
+  default     = "https://libraries.cgr.dev"
+
+  validation {
+    condition     = can(regex("^https?://[^/]+$", var.chainguard_libraries_url))
+    error_message = "chainguard_libraries_url must be a scheme + host with no path or trailing slash, e.g. https://libraries.cgr.dev."
+  }
+}
+
+variable "remediated_index_path" {
+  description = "Path segment for the Chainguard remediated Python index, appended to chainguard_libraries_url."
+  type        = string
+  default     = "python-remediated"
+}
+
+variable "chainguard_index_path" {
+  description = "Path segment for the Chainguard standard Python index, appended to chainguard_libraries_url."
+  type        = string
+  default     = "python"
+}
+
+variable "chainguard_username" {
+  description = "Username (identity ID) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "chainguard_password" {
+  description = "Password (token) used to authenticate to the Chainguard Libraries service. Retrieve with chainctl auth."
+  type        = string
+  sensitive   = true
+}
+
+variable "description" {
+  description = "Optional description applied to the created repositories."
+  type        = string
+  default     = "Chainguard Libraries for Python"
+}
+
+variable "project_key" {
+  description = "Optional Artifactory project key to assign the repositories to."
+  type        = string
+  default     = ""
+}
+
+variable "default_deployment_repo" {
+  description = "Optional key of a local repository to use as the default deployment target on the virtual repository. Leave empty to disable deployments through the virtual."
+  type        = string
+  default     = ""
+}

--- a/terraform-modules/artifactory-python-fallback/versions.tf
+++ b/terraform-modules/artifactory-python-fallback/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    artifactory = {
+      source  = "jfrog/artifactory"
+      version = ">= 12.0.0"
+    }
+  }
+}


### PR DESCRIPTION
You need to configure Artifactory repositories with quite a specific combination of settings for it to work nicely with Chainguard libraries. This change adds a set of terraform modules that configure things as recommended by our docs.

This makes it easier and less error-prone to stand up a working configuration. It also makes it easier to reset to baseline after tweaking settings. Finally, it provides an easy way to identify regressions where our recommended setup breaks due to some change in how we serve things.